### PR TITLE
mark-devkit: [mark-unstable] Bump virtual/dracut-mark-1

### DIFF
--- a/virtual/dracut-mark/dracut-mark-1.ebuild
+++ b/virtual/dracut-mark/dracut-mark-1.ebuild
@@ -1,0 +1,16 @@
+# Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
+
+EAPI=7
+
+DESCRIPTION="A virtual package that installs a Dracut config for MARK"
+SLOT="0"
+KEYWORDS="*"
+S="${WORKDIR}"
+src_install() {
+	insinto /etc/dracut.conf.d/
+	newins ${FILESDIR}/dracut-mark.conf 99-macaroni.conf
+}
+
+
+# vim: filetype=ebuild

--- a/virtual/dracut-mark/files/dracut-mark.conf
+++ b/virtual/dracut-mark/files/dracut-mark.conf
@@ -1,0 +1,8 @@
+# Macaroni OS (MARK) Dracut Default parameters
+
+dracutmodules="rescue resume bash kernel-modules rootfs-block udev-rules usrmount base fs-lib shutdown terminfo shutdown"
+
+omit_dracutmodules="fcoe"
+
+# Quiet messages: failed to execute '/lib64/elogind/elogind-uaccess-command' '/lib64/elogind/elogind-uaccess-command /dev/dri/card0 ': No such file or directory
+install_items="/lib64/elogind/elogind-uaccess-command"


### PR DESCRIPTION
Automatic bump of package virtual/dracut-mark-1 for branch mark-unstable by mark-bot