### PR TITLE
mark-devkit: [mark-unstable] Bump sys-kernel/debian-sources-6.12.73_p1-r200

### DIFF
--- a/sys-kernel/debian-sources/debian-sources-6.12.73_p1-r200.ebuild
+++ b/sys-kernel/debian-sources/debian-sources-6.12.73_p1-r200.ebuild
@@ -1,0 +1,428 @@
+# Distributed under the terms of the GNU General Public License v2
+# Created by MARK Devkit
+
+EAPI=6
+
+inherit check-reqs eutils ego savedconfig
+
+SLOT=trixie/6.12.73_p1
+
+# NOTE: When updating: use the version from Debian testing (trixie)
+# https://packages.debian.org/trixie/linux-source
+DEB_PATCHLEVEL="1"
+KERNEL_TRIPLET="6.12.73"
+
+# like "_p1-r1"
+#VERSION_SUFFIX="_p${DEB_PATCHLEVEL}"
+if [ ${PR} != "r0" ]; then
+	REVISION_SUFFIX+="-${PR}"
+fi
+
+MACARONI_KTYPE="debian"
+MACARONI_KSUFFIX="debian${DEB_PATCHLEVEL}-mark"
+# like "-r1-debian1-mark"
+EXTRAVERSION="${REVISION_SUFFIX}-${MACARONI_KSUFFIX}"
+# like "6.12.38-r1"
+MACARONI_KVER="${KERNEL_TRIPLET}${REVISION_SUFFIX}"
+# like "6.12.38-r1-debian1-mark"
+# same as ${KERNEL_TRIPLET}${EXTRAVERSION}
+MOD_DIR_NAME="${KERNEL_TRIPLET}${REVISION_SUFFIX}-${MACARONI_KSUFFIX}"
+
+# install sources to /usr/src/$LINUX_SRCDIR
+LINUX_SRCDIR=linux-${PF}
+DEB_PV="${KERNEL_TRIPLET}-${DEB_PATCHLEVEL}"
+
+RESTRICT="binchecks strip"
+LICENSE="GPL-2"
+KEYWORDS="*"
+IUSE="acpi-ec binary btrfs custom-cflags dracut ec2 +logo luks lvm mdadm savedconfig sshd sign-modules zfs
+"
+
+RDEPEND="sys-apps/gawk
+dracut? (
+  sys-apps/whip-catalog
+  sys-kernel/dracut
+  virtual/dracut-mark
+)
+"
+DEPEND="virtual/libelf
+btrfs? ( sys-fs/btrfs-progs )
+zfs? ( sys-fs/zfs )
+luks? ( sys-fs/cryptsetup )
+lvm? ( sys-fs/lvm2 )
+mdadm? ( sys-fs/mdadm )
+"
+REQUIRED_USE="binary? (
+  ^^ ( dracut )
+  btrfs? ( dracut )
+  mdadm? ( dracut )
+  luks? ( dracut )
+  lvm? ( dracut )
+  sshd? ( dracut )
+)
+sshd? ( binary )
+"
+
+DESCRIPTION="Debian Sources (and optional binary kernel)"
+HOMEPAGE="https://packages.debian.org/unstable/kernel/"
+SRC_URI="
+https://deb.debian.org/debian/pool/main/l/linux/linux_6.12.73-1.debian.tar.xz -> linux_6.12.73-1.debian.tar.xz
+https://mirrors.edge.kernel.org/pub/linux/kernel/v6.x/linux-6.12.73.tar.xz -> linux-6.12.73.tar.xz"
+S="$WORKDIR/linux-${KERNEL_TRIPLET}"
+
+
+get_patch_list() {
+	[[ -z "${1}" ]] && die "No patch series file specified"
+	local patch_series="${1}"
+	while read line ; do
+		if [[ "${line:0:1}" != "#" ]] ; then
+			echo "${line}"
+		fi
+	done < "${patch_series}"
+}
+
+tweak_config() {
+	einfo "Setting $2=$3 in kernel config."
+	sed -i -e "/^$2=/d" $1
+	echo "$2=$3" >> $1
+}
+
+setno_config() {
+	einfo "Setting $2*=y to n in kernel config."
+	sed -i -e "s/^$2\(.*\)=.*/$2\1=n/g" $1
+}
+
+setyes_config() {
+	einfo "Setting $2*=* to y in kernel config."
+	sed -i -e "s/^$2\(.*\)=.*/$2\1=y/g" $1
+}
+
+zap_config() {
+	einfo "Removing *$2* from kernel config."
+	sed -i -e "/$2/d" $1
+}
+
+get_vendor() {
+	vendor_string=$(grep vendor /proc/cpuinfo | uniq | cut -d ':' -f 2)
+	vendor=$([[ ${vendor_string^^} =~ (INTEL)|(AMD) ]] && echo ${BASH_REMATCH[0]})
+	echo $vendor
+}
+
+pkg_pretend() {
+	# Ensure we have enough disk space to compile
+	if use binary ; then
+		CHECKREQS_DISK_BUILD="6G"
+		check-reqs_pkg_setup
+		echo "binary"
+	fi
+}
+
+get_certs_dir() {
+	# find a certificate dir in /etc/kernel/certs/ that contains signing cert for modules.
+	for subdir in $PF $P linux; do
+		certdir=/etc/kernel/certs/$subdir
+		if [ -d $certdir ]; then
+			if [ ! -e $certdir/signing_key.pem ]; then
+				eerror "$certdir exists but missing signing key; exiting."
+				exit 1
+			fi
+			echo $certdir
+			return
+		fi
+	done
+}
+
+pkg_setup() {
+	export REAL_ARCH="$ARCH"
+	unset ARCH; unset LDFLAGS #will interfere with Makefile if set
+	export FEATURESET="standard"
+}
+
+src_prepare() {
+	default
+	for debpatch in $( get_patch_list "${WORKDIR}/debian/patches/series" ); do
+		epatch -p1 "${WORKDIR}/debian/patches/${debpatch}"
+	done
+
+	# do not include debian devs certificates
+	rm -rf "${WORKDIR}"/debian/certs
+
+	# remove references to debian uefi certs
+	sed -i -e 's|\${CURDIR}\/debian\/certs\/debian-uefi-certs\.pem||g' "${WORKDIR}"/debian/rules.gen
+
+	sed -i -e "s:^\(EXTRAVERSION =\).*:\1 ${EXTRAVERSION}:" Makefile || die
+	sed	-i -e 's:#export\tINSTALL_PATH:export\tINSTALL_PATH:' Makefile || die
+	rm -f .config >/dev/null
+	cp -a "${WORKDIR}"/debian "${T}"
+	make -s mrproper || die "make mrproper failed"
+	cd "${S}" || die
+	cp -aR "${WORKDIR}"/debian "${S}"/debian
+
+	# patches common to all kernel versions
+	epatch "${FILESDIR}"/latest/ikconfig.patch || die
+	epatch "${FILESDIR}"/latest/mcelog.patch || die
+
+	# patches for this particular branch
+	epatch "${FILESDIR}"/6.1.79+/more-ISA-levels-and-uarches-for-kernel-6.1.79+.patch || die
+
+	if use savedconfig; then
+		einfo Restoring saved .config ...
+		restore_config .config
+	else
+		cp "${FILESDIR}"/config-extract-6.6 ./config-extract || die
+		chmod +x config-extract || die
+	fi
+
+	# Set up arch-specific variables and this will fail if run in pkg_setup()
+	# since ARCH can be unset there:
+	if [ "${REAL_ARCH}" = x86 ]; then
+		export DEB_ARCH="i386"
+		export DEB_SUBARCH="686-pae"
+		export KERN_ARCH="i686"
+	elif [ "${REAL_ARCH}" = amd64 ]; then
+		export DEB_ARCH="amd64"
+		export DEB_SUBARCH="amd64"
+		export KERN_ARCH="x86_64"
+	else
+		die "Architecture '${REAL_ARCH}' not handled in ebuild"
+	fi
+	# like "debian-x86_64-6.12.38-r1-debian1-mark"
+	export KERN_SUFFIX="${MACARONI_KTYPE}-${KERN_ARCH}-${MACARONI_KVER}-${MACARONI_KSUFFIX}"
+
+	if ! use savedconfig; then
+		./config-extract ${DEB_ARCH} ${FEATURESET} ${DEB_SUBARCH} || die
+	fi
+
+	setno_config .config CONFIG_DEBUG
+	if use acpi-ec; then
+		# most fan control tools require this
+		tweak_config .config CONFIG_ACPI_EC_DEBUGFS m
+		tweak_config .config CONFIG_DEBUG_FS y
+	fi
+	if use ec2; then
+		setyes_config .config CONFIG_BLK_DEV_NVME
+		setyes_config .config CONFIG_XEN_BLKDEV_FRONTEND
+		setyes_config .config CONFIG_XEN_BLKDEV_BACKEND
+		setyes_config .config CONFIG_IXGBEVF
+	fi
+	if use logo; then
+		cp "${FILESDIR}"/latest/macaroni-os_logo_clut224.ppm "$S"/drivers/video/logo/logo_linux_clut224.ppm || die
+		tweak_config .config CONFIG_LOGO y
+		ewarn "Linux kernel frame buffer boot logo is now enabled with a custom MacaroniOS pixmap."
+		ewarn "The new logo can be viewed at /usr/src/linux/drivers/video/logo/logo_linux_clut224.ppm"
+		ewarn "Remove the quiet kernel parameter (from params in /etc/boot.conf, and re-run boot-update)."
+		ewarn "This will ensure the custom kernel logo is displayed during boot over frame buffer."
+		ewarn ""
+	fi
+	if use sign-modules; then
+		certs_dir=$(get_certs_dir)
+		echo
+		if [ -z "$certs_dir" ]; then
+			eerror "No certs dir found in /etc/kernel/certs; aborting."
+			die
+		else
+			einfo "Using certificate directory of $certs_dir for kernel module signing."
+		fi
+		echo
+		# turn on options for signing modules.
+		# first, remove existing configs and comments:
+		zap_config .config CONFIG_MODULE_SIG
+		# now add our settings:
+		tweak_config .config CONFIG_MODULE_SIG y
+		tweak_config .config CONFIG_MODULE_SIG_FORCE n
+		tweak_config .config CONFIG_MODULE_SIG_ALL n
+		tweak_config .config CONFIG_MODULE_SIG_HASH \"sha512\"
+		tweak_config .config CONFIG_MODULE_SIG_KEY  \"${certs_dir}/signing_key.pem\"
+		tweak_config .config CONFIG_SYSTEM_TRUSTED_KEYRING y
+		tweak_config .config CONFIG_SYSTEM_EXTRA_CERTIFICATE y
+		tweak_config .config CONFIG_SYSTEM_EXTRA_CERTIFICATE_SIZE 4096
+		echo "CONFIG_MODULE_SIG_SHA512=y" >> .config
+		ewarn "This kernel will ALLOW non-signed modules to be loaded with a WARNING."
+		ewarn "To enable strict enforcement, YOU MUST add module.sig_enforce=1 as a kernel boot"
+		ewarn "parameter (to params in /etc/boot.conf, and re-run boot-update.)"
+		ewarn ""
+	else
+		tweak_config .config CONFIG_MODULE_SIG n
+	fi
+	if use custom-cflags; then
+		MARCH="$(python3 -c "import portage; print(portage.settings[\"CFLAGS\"])" | sed 's/ /\n/g' | grep "march")"
+
+		if [ -n "$MARCH" ]; then
+			if [[ $MARCH =~ (native) ]] && [[ -n $(get_vendor) ]]; then
+				einfo "Detected -march=native on $(get_vendor)"
+				CONFIG_MARCH=CONFIG_MNATIVE_$(get_vendor)
+			else
+				CONFIG_MARCH="$(grep -m 1 -e "${MARCH}" -B 1 arch/x86/Makefile | sort -r | grep -m 1 -o CONFIG_\[^\)\]* )"
+			fi
+
+			if [ -n "${CONFIG_MARCH}" ]; then
+				einfo "Optimizing kernel for ${CONFIG_MARCH}"
+				tweak_config .config CONFIG_GENERIC_CPU n
+				tweak_config .config "${CONFIG_MARCH}" y
+			else
+				ewarn "Could not find optimized settings for $MARCH, compiling generic kernel."
+			fi
+		fi
+	fi
+	# build generic CRC32C module into kernel, to defeat FL-11913
+	# (cannot mount ext4 filesystem in initramfs if created with recent e2fsprogs version)
+	tweak_config .config CONFIG_CRYPTO_CRC32C y
+
+	# disable module compression until the initramfs plays nicely with it
+	tweak_config .config CONFIG_MODULE_COMPRESS n
+	tweak_config .config CONFIG_MODULE_COMPRESS_XZ n
+	tweak_config .config CONFIG_MODULE_COMPRESS_GZIP n
+	tweak_config .config CONFIG_MODULE_COMPRESS_ALL n
+	tweak_config .config CONFIG_MODULE_COMPRESS_NONE y
+
+	# get config into good state:
+	yes "" | make oldconfig >/dev/null 2>&1 || die
+	cp .config "${T}"/config || die
+	make -s mrproper || die "make mrproper failed"
+}
+
+src_compile() {
+	! use binary && return
+	install -d "${WORKDIR}"/build
+	cp "${T}"/config "${WORKDIR}"/build/.config || die "couldn't copy kernel config"
+	make ${MAKEOPTS} O="${WORKDIR}"/build bzImage || die "kernel build failure"
+	make ${MAKEOPTS} O="${WORKDIR}"/build modules || die "modules build failure"
+}
+
+src_install() {
+	# copy sources into place:
+	dodir /usr/src
+	cp -a "${S}" "${D}"/usr/src/${LINUX_SRCDIR} || die
+	cd "${D}"/usr/src/${LINUX_SRCDIR}
+	# prepare for real-world use and 3rd-party module building:
+	make mrproper || die
+	cp "${T}"/config .config || die
+	cp -a "${T}"/debian debian || die
+
+	# if we didn't compile a kernel, we're done. The kernel source tree is left in
+	# an unconfigured state - you can't compile 3rd-party modules against it yet.
+	use binary || return
+	make ${MAKEOPTS} O="${WORKDIR}"/build INSTALL_MOD_PATH="${D}" modules_install || die "modules install failure"
+	insinto /boot
+	newins ${WORKDIR}/build/arch/x86/boot/bzImage "vmlinuz-${KERN_SUFFIX}.tmp"
+	newins ${WORKDIR}/build/System.map "System.map-${KERN_SUFFIX}.tmp"
+	newins ${WORKDIR}/build/.config "config-${KERN_SUFFIX}.tmp"
+	make prepare || die
+	make scripts || die
+	# FL-8004: In Linux 5.10, module.lds is generated by 'modules_prepare',
+	# so we need to run it as well to be able to compile modules
+	make modules_prepare || die
+
+	# module symlink fixup:
+	rm -f "${D}"/lib/modules/*/source || die
+	rm -f "${D}"/lib/modules/*/build || die
+	cd "${D}"/lib/modules
+	local moddir="$(ls -d [1-9]*)"
+	ln -s /usr/src/${LINUX_SRCDIR} "${D}"/lib/modules/${moddir}/source || die
+	ln -s /usr/src/${LINUX_SRCDIR} "${D}"/lib/modules/${moddir}/build || die
+	# Fixes FL-14
+	cp "${WORKDIR}/build/System.map" "${D}/usr/src/${LINUX_SRCDIR}/" || die
+	cp "${WORKDIR}/build/Module.symvers" "${D}/usr/src/${LINUX_SRCDIR}/" || die
+	if use sign-modules; then
+		# TODO FIXME: check for compressed modules.
+		find "${D}"/lib/modules -iname *.ko -exec ${WORKDIR}/build/scripts/sign-file sha512 $certs_dir/signing_key.pem $certs_dir/signing_key.x509 {} \; || die
+		# install the sign-file executable for future use.
+		exeinto /usr/src/${LINUX_SRCDIR}/scripts
+		doexe ${WORKDIR}/build/scripts/sign-file
+	fi
+	# The following line associates the .tmp dir with this package, so that
+	# when the package is uninstalled, the modules are not removed.
+	# Otherwise, modules for the current running kernel might be erased!
+	mv "${D}"/lib/modules/${MOD_DIR_NAME}{,.tmp}
+}
+
+pkg_postinst() {
+	# Ensure that /boot is mounted in this phase
+	ego_pkg_preinst
+
+	# Prevent kernel and modules erasure during upgrade.
+	if use binary; then
+		# first rename the initramfs
+		if use savedconfig; then
+			if [[ -f "/boot/initramfs-${KERN_SUFFIX}" ]]; then
+				mv /boot/initramfs-${KERN_SUFFIX}{,.old} || die
+			fi
+		fi
+		# then rename everything else, and copy the new files into place
+		for i in {vmlinuz,System.map,config}; do
+			if [[ -f "/boot/$i-${KERN_SUFFIX}" ]]; then
+				# USE=savedconfig means the config might have changed!
+				# In that case, keep the old kernel around, for safety.
+				if use savedconfig; then
+					if [[ -f /boot/$i-${KERN_SUFFIX}.old ]]; then
+						rm /boot/$i-${KERN_SUFFIX}.old
+					fi
+					einfo "Preserving: mv /boot/$i-${KERN_SUFFIX}{,.old}"
+					mv /boot/$i-${KERN_SUFFIX}{,.old} || die
+				else
+					rm /boot/$i-${KERN_SUFFIX} || die
+				fi
+			fi
+			mv /boot/$i-${KERN_SUFFIX}{.tmp,} || die
+		done
+		if [[ -d "/lib/modules/${MOD_DIR_NAME}" ]]; then
+			# USE=savedconfig means the config might have changed!
+			# In that case, keep the old modules around, for safety.
+			if use savedconfig; then
+				if [[ -d "/lib/modules/${MOD_DIR_NAME}.old" ]]; then
+					rm -r /lib/modules/${MOD_DIR_NAME}.old
+				fi
+				einfo "Preserving: mv /lib/modules/${MOD_DIR_NAME}{,.old}"
+				mv /lib/modules/${MOD_DIR_NAME}{,.old} || die
+			else
+				rm -r /lib/modules/${MOD_DIR_NAME} || die
+			fi
+		fi
+		mv /lib/modules/${MOD_DIR_NAME}{.tmp,} || die
+	fi
+
+	# Finally, generate a new initramfs with dracut, via whip
+	# NOTE: For now, the initramfs is generic.
+	if use binary && use dracut; then
+		dracut_modules_pre="
+			$(use lvm && echo lvm)
+			$(use luks && echo crypt)
+			$(use mdadm && echo mdraid)
+			$(use btrfs && echo btrfs)
+			$(use sshd && echo sshd)
+		"
+		dracut_drivers_pre="
+			$(use luks && echo dm-crypt)
+		"
+		DRACUT_ADD_MODULES="$(echo ${dracut_modules_pre} | xargs)" \
+		DRACUT_ADD_DRIVERS="$(echo ${dracut_drivers_pre} | xargs)" \
+		KVER="${KERN_ARCH}-${MACARONI_KVER}" \
+		KTYPE="${MACARONI_KTYPE}" \
+		KSUFFIX="${MACARONI_KSUFFIX}" \
+		KMODDIR="/lib/modules/$MOD_DIR_NAME" \
+		whip h initramfs.generate_with_dracut || die
+	fi
+
+	if use binary && [[ -h "${ROOT}"usr/src/linux ]]; then
+		rm "${ROOT}"usr/src/linux || die
+	fi
+
+	if use binary && [[ ! -e "${ROOT}"usr/src/linux ]]; then
+		ewarn "With binary use flag enabled /usr/src/linux"
+		ewarn "symlink automatically set to debian kernel"
+		ewarn "If you have external modules, don't forget to rebuild them with:"
+		ewarn ""
+		ewarn "  emerge @module-rebuild"
+		ewarn ""
+		ln -sf ${LINUX_SRCDIR} "${ROOT}"usr/src/linux || die
+	fi
+
+	if [ -e ${ROOT}lib/modules ]; then
+		depmod -a $MOD_DIR_NAME || die
+	fi
+
+	# Update bootloader and unmount /boot
+	ego_pkg_postinst
+}
+
+# vim: syn=ebuild noet ts=4


### PR DESCRIPTION
Automatic bump of package sys-kernel/debian-sources-6.12.73_p1-r200 for branch mark-unstable by mark-bot