### PR TITLE
mark-devkit: [mark-xl] Bump virtual/os-headers-1

### DIFF
--- a/virtual/os-headers/os-headers-1.ebuild
+++ b/virtual/os-headers/os-headers-1.ebuild
@@ -1,0 +1,14 @@
+# Distributed under the terms of the GNU General Public License v2
+# Autogen by MARK Devkit
+
+EAPI=7
+
+DESCRIPTION="Virtual for operating system headers"
+SLOT="0"
+KEYWORDS="*"
+RDEPEND="sys-kernel/linux-headers
+"
+DEPEND="${RDEPEND}
+"
+
+# vim: filetype=ebuild


### PR DESCRIPTION
Automatic bump of package virtual/os-headers-1 for branch mark-xl by mark-bot